### PR TITLE
Fix deletion of completed checklist tasks

### DIFF
--- a/Android/app/src/main/java/dao/WidgetCheckListDao.java
+++ b/Android/app/src/main/java/dao/WidgetCheckListDao.java
@@ -39,4 +39,7 @@ public interface WidgetCheckListDao {
 
     @Query("DELETE FROM events_new")
     void deleteAll();
+
+    @Query("DELETE FROM events_new WHERE isDone = 1")
+    void deleteCompletedTasks();
 }


### PR DESCRIPTION
## Summary
- fix bug deleting all widget items instead of completed ones
- bulk insert for undo action

## Testing
- `./gradlew assembleDebug assembleRelease` *(fails: No route to host)*
- `./gradlew checkstyle` *(fails: No route to host)*