### PR TITLE
Use env-based Cloudinary config

### DIFF
--- a/Android/app/build.gradle
+++ b/Android/app/build.gradle
@@ -3,6 +3,10 @@ apply from: '../config/checkstyle.gradle'
 apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
 
+def cloudinaryCloudName = System.getenv('CLOUDINARY_CLOUD_NAME') ?: ''
+def cloudinaryApiKey = System.getenv('CLOUDINARY_API_KEY') ?: ''
+def cloudinaryApiSecret = System.getenv('CLOUDINARY_API_SECRET') ?: ''
+
 android {
     compileSdkVersion 28
     defaultConfig {
@@ -11,6 +15,9 @@ android {
         targetSdkVersion 28
         versionCode 49
         versionName "5.6.2"
+        buildConfigField "String", "CLOUDINARY_CLOUD_NAME", "\"${cloudinaryCloudName}\""
+        buildConfigField "String", "CLOUDINARY_API_KEY", "\"${cloudinaryApiKey}\""
+        buildConfigField "String", "CLOUDINARY_API_SECRET", "\"${cloudinaryApiSecret}\""
     }
 
     lintOptions {

--- a/Android/app/src/main/java/utils/Constants.java
+++ b/Android/app/src/main/java/utils/Constants.java
@@ -1,5 +1,6 @@
 package utils;
 
+import io.github.project_travel_mate.BuildConfig;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -27,11 +28,10 @@ public class Constants {
     public static final String API_LINK_V2 = "https://project-travel-mate.herokuapp.com/api/";
     public static final String AUTHORIZATION = "Authorization";
 
-    // TODO:: replace placeholders with actual values
-    //Cloudinary information
-    public static final String CLOUDINARY_CLOUD_NAME = "sample_cloud";
-    public static final String CLOUDINARY_API_KEY = "sample_api_key";
-    public static final String CLOUDINARY_API_SECRET = "sample_api_secret";
+    //Cloudinary information loaded from environment variables via BuildConfig
+    public static final String CLOUDINARY_CLOUD_NAME = BuildConfig.CLOUDINARY_CLOUD_NAME;
+    public static final String CLOUDINARY_API_KEY = BuildConfig.CLOUDINARY_API_KEY;
+    public static final String CLOUDINARY_API_SECRET = BuildConfig.CLOUDINARY_API_SECRET;
 
 
     public static final List<String> BASE_TASKS = new ArrayList<String>() {


### PR DESCRIPTION
## Summary
- load Cloudinary credentials from environment variables via `BuildConfig`
- remove placeholder constants

## Testing
- `./gradlew tasks` *(fails: No route to host)*