### PR TITLE
Add basic locale support

### DIFF
--- a/Android/app/src/main/java/io/github/project_travel_mate/SettingsFragment.java
+++ b/Android/app/src/main/java/io/github/project_travel_mate/SettingsFragment.java
@@ -23,6 +23,9 @@ import android.view.inputmethod.InputMethodManager;
 import android.widget.EditText;
 import android.widget.LinearLayout;
 import android.widget.Switch;
+import android.widget.Spinner;
+import android.widget.ArrayAdapter;
+import android.widget.AdapterView;
 
 import com.airbnb.lottie.LottieAnimationView;
 import com.dd.processbutton.iml.ActionProcessButton;
@@ -43,6 +46,8 @@ import okhttp3.Request;
 import okhttp3.RequestBody;
 import okhttp3.Response;
 import utils.TravelmateSnackbars;
+import utils.LocaleHelper;
+import utils.Constants;
 
 import static utils.Constants.API_LINK_V2;
 import static utils.Constants.QUOTES_SHOW_DAILY;
@@ -55,6 +60,8 @@ public class SettingsFragment extends Fragment {
     Switch notificationSwitch;
     @BindView(R.id.switch_quotes)
     Switch quoteSwitch;
+    @BindView(R.id.language_spinner)
+    android.widget.Spinner languageSpinner;
     @BindView(R.id.old_password)
     EditText oldPasswordText;
     @BindView(R.id.new_password)
@@ -144,7 +151,67 @@ public class SettingsFragment extends Fragment {
                 mSharedPreferences.edit().putBoolean(QUOTES_SHOW_DAILY, false).apply();
             }
         });
+
+        setupLanguageSpinner();
         return mView;
+    }
+
+    private void setupLanguageSpinner() {
+        ArrayAdapter<CharSequence> adapter = ArrayAdapter.createFromResource(mActivity,
+                R.array.language_options, android.R.layout.simple_spinner_item);
+        adapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
+        languageSpinner.setAdapter(adapter);
+        String current = mSharedPreferences.getString(Constants.APP_LANGUAGE, "en");
+        int pos = getLanguagePosition(current);
+        languageSpinner.setSelection(pos);
+        languageSpinner.setOnItemSelectedListener(new AdapterView.OnItemSelectedListener() {
+            @Override
+            public void onItemSelected(AdapterView<?> parent, View view, int position, long id) {
+                String code = getLanguageCode(position);
+                if (!code.equals(current)) {
+                    mSharedPreferences.edit().putString(Constants.APP_LANGUAGE, code).apply();
+                    LocaleHelper.setLocale(mActivity, code);
+                    mActivity.recreate();
+                }
+            }
+
+            @Override
+            public void onNothingSelected(AdapterView<?> parent) { }
+        });
+    }
+
+    private int getLanguagePosition(String code) {
+        switch (code) {
+            case "ru":
+                return 1;
+            case "de":
+                return 2;
+            case "es":
+                return 3;
+            case "ar":
+                return 4;
+            case "zh":
+                return 5;
+            default:
+                return 0;
+        }
+    }
+
+    private String getLanguageCode(int position) {
+        switch (position) {
+            case 1:
+                return "ru";
+            case 2:
+                return "de";
+            case 3:
+                return "es";
+            case 4:
+                return "ar";
+            case 5:
+                return "zh";
+            default:
+                return "en";
+        }
     }
 
     /**

--- a/Android/app/src/main/java/io/github/project_travel_mate/TravelMateApplication.java
+++ b/Android/app/src/main/java/io/github/project_travel_mate/TravelMateApplication.java
@@ -3,6 +3,11 @@ package io.github.project_travel_mate;
 import android.app.Application;
 
 import com.blongho.country_data.World;
+import android.content.SharedPreferences;
+import android.preference.PreferenceManager;
+
+import utils.Constants;
+import utils.LocaleHelper;
 
 public class TravelMateApplication extends Application {
 
@@ -12,5 +17,9 @@ public class TravelMateApplication extends Application {
 
         // Initialize the World library
         World.init(this);
+
+        SharedPreferences pref = PreferenceManager.getDefaultSharedPreferences(this);
+        String lang = pref.getString(Constants.APP_LANGUAGE, "en");
+        LocaleHelper.setLocale(this, lang);
     }
 }

--- a/Android/app/src/main/java/utils/Constants.java
+++ b/Android/app/src/main/java/utils/Constants.java
@@ -17,6 +17,7 @@ public class Constants {
     public static final String USER_ID = "user_id";
     public static final String OTHER_USER_ID = "other_user_id";
     public static final String READ_NOTIF_STATUS = "read_notificatons_status";
+    public static final String APP_LANGUAGE = "app_language";
 
     public static final String EVENT_IMG = "event_name";
     public static final String EVENT_NAME = "event_img";

--- a/Android/app/src/main/java/utils/LocaleHelper.java
+++ b/Android/app/src/main/java/utils/LocaleHelper.java
@@ -1,0 +1,20 @@
+package utils;
+
+import android.content.Context;
+import android.content.res.Configuration;
+
+import java.util.Locale;
+
+public class LocaleHelper {
+    public static void setLocale(Context context, String languageCode) {
+        if (languageCode == null || languageCode.isEmpty()) {
+            return;
+        }
+        Locale locale = new Locale(languageCode);
+        Locale.setDefault(locale);
+        Configuration config = context.getResources().getConfiguration();
+        config.setLocale(locale);
+        context.getResources().updateConfiguration(config,
+                context.getResources().getDisplayMetrics());
+    }
+}

--- a/Android/app/src/main/res/layout/fragment_settings.xml
+++ b/Android/app/src/main/res/layout/fragment_settings.xml
@@ -56,6 +56,29 @@
                     android:checked="false" />
             </LinearLayout>
 
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginLeft="1dp"
+                android:layout_marginRight="2dp"
+                android:layout_marginTop="10dp">
+
+                <TextView
+                    android:id="@+id/select_language_text"
+                    android:layout_width="0dp"
+                    android:layout_height="match_parent"
+                    android:layout_weight="3"
+                    android:text="@string/select_language_prompt"
+                    android:textColor="@color/black"
+                    android:textSize="15sp" />
+
+                <Spinner
+                    android:id="@+id/language_spinner"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1" />
+            </LinearLayout>
+
             <View
                 android:layout_width="match_parent"
                 android:layout_height="2dp"

--- a/Android/app/src/main/res/values-ar/strings.xml
+++ b/Android/app/src/main/res/values-ar/strings.xml
@@ -1,0 +1,4 @@
+<resources>
+    <string name="app_name">رفيق السفر</string>
+    <string name="select_language_prompt">اختر اللغة</string>
+</resources>

--- a/Android/app/src/main/res/values-de/strings.xml
+++ b/Android/app/src/main/res/values-de/strings.xml
@@ -1,0 +1,4 @@
+<resources>
+    <string name="app_name">Reisebegleiter</string>
+    <string name="select_language_prompt">Sprache wählen</string>
+</resources>

--- a/Android/app/src/main/res/values-es/strings.xml
+++ b/Android/app/src/main/res/values-es/strings.xml
@@ -1,0 +1,4 @@
+<resources>
+    <string name="app_name">Compañero de viaje</string>
+    <string name="select_language_prompt">Seleccionar idioma</string>
+</resources>

--- a/Android/app/src/main/res/values-ru/strings.xml
+++ b/Android/app/src/main/res/values-ru/strings.xml
@@ -1,0 +1,4 @@
+<resources>
+    <string name="app_name">Путешественник</string>
+    <string name="select_language_prompt">Выберите язык</string>
+</resources>

--- a/Android/app/src/main/res/values-zh/strings.xml
+++ b/Android/app/src/main/res/values-zh/strings.xml
@@ -1,0 +1,4 @@
+<resources>
+    <string name="app_name">旅行伙伴</string>
+    <string name="select_language_prompt">选择语言</string>
+</resources>

--- a/Android/app/src/main/res/values/arrays.xml
+++ b/Android/app/src/main/res/values/arrays.xml
@@ -1,0 +1,10 @@
+<resources>
+    <string-array name="language_options">
+        <item>English</item>
+        <item>Русский</item>
+        <item>Deutsch</item>
+        <item>Español</item>
+        <item>العربية</item>
+        <item>中文</item>
+    </string-array>
+</resources>

--- a/Android/app/src/main/res/values/strings.xml
+++ b/Android/app/src/main/res/values/strings.xml
@@ -326,6 +326,7 @@
     <string name="new_password">New Password</string>
     <string name="read_notifications_message">Show my read notifications</string>
     <string name="show_quotes_message">Show daily quotes</string>
+    <string name="select_language_prompt">Select language</string>
     <string name="required_error">Required!</string>
     <string name="password_updated">Password Updated!</string>
     <string name="status_character_limit">/100</string>


### PR DESCRIPTION
## Summary
- add Language dropdown in Settings
- support for Russian, German, Spanish, Arabic and Chinese locales
- remember selected language
- apply saved locale on app start

## Testing
- `./gradlew test` *(fails: No route to host)*