### PR TITLE
Add premium subscription skeleton

### DIFF
--- a/Android/app/src/main/java/io/github/project_travel_mate/premium/ConciergeService.java
+++ b/Android/app/src/main/java/io/github/project_travel_mate/premium/ConciergeService.java
@@ -1,0 +1,17 @@
+package io.github.project_travel_mate.premium;
+
+import java.util.Collections;
+import java.util.List;
+
+public class ConciergeService {
+
+    public String startChatSupport(String userId) {
+        // Placeholder for real-time chat support
+        return "Chat session started for " + userId;
+    }
+
+    public List<String> getHiddenGems(String city) {
+        // Placeholder for hidden gem recommendations
+        return Collections.singletonList("Explore hidden gems of " + city);
+    }
+}

--- a/Android/app/src/main/java/io/github/project_travel_mate/premium/ItineraryGenerator.java
+++ b/Android/app/src/main/java/io/github/project_travel_mate/premium/ItineraryGenerator.java
@@ -1,0 +1,14 @@
+package io.github.project_travel_mate.premium;
+
+import objects.Trip;
+
+public class ItineraryGenerator {
+
+    public static String generateItinerary(Trip trip) {
+        // Placeholder for future itinerary generation logic
+        if (trip == null) {
+            return "No trip information";
+        }
+        return "Sample itinerary for " + trip.getTname();
+    }
+}

--- a/Android/app/src/main/java/io/github/project_travel_mate/premium/PremiumManager.java
+++ b/Android/app/src/main/java/io/github/project_travel_mate/premium/PremiumManager.java
@@ -1,0 +1,15 @@
+package io.github.project_travel_mate.premium;
+
+import objects.SubscriptionTier;
+import objects.User;
+
+public class PremiumManager {
+
+    public static boolean hasItineraryAccess(User user) {
+        return user.getSubscriptionTier() != SubscriptionTier.BASIC;
+    }
+
+    public static boolean hasConciergeAccess(User user) {
+        return user.getSubscriptionTier() == SubscriptionTier.CONCIERGE;
+    }
+}

--- a/Android/app/src/main/java/objects/SubscriptionTier.java
+++ b/Android/app/src/main/java/objects/SubscriptionTier.java
@@ -1,0 +1,7 @@
+package objects;
+
+public enum SubscriptionTier {
+    BASIC,
+    PRO,
+    CONCIERGE
+}

--- a/Android/app/src/main/java/objects/User.java
+++ b/Android/app/src/main/java/objects/User.java
@@ -9,9 +9,11 @@ public class User {
     private String mImage;
     private String mDateJoined;
     private String mStatus;
+    private SubscriptionTier mSubscriptionTier = SubscriptionTier.BASIC;
 
     public User(String mUsername, String mFirstName, String mLastName,
-                int mId, String mImage, String mDateJoined, String mStatus) {
+                int mId, String mImage, String mDateJoined, String mStatus,
+                SubscriptionTier tier) {
         this.mUsername = mUsername;
         this.mFirstName = mFirstName;
         this.mLastName = mLastName;
@@ -19,6 +21,13 @@ public class User {
         this.mImage = mImage;
         this.mDateJoined = mDateJoined;
         this.mStatus = mStatus;
+        this.mSubscriptionTier = tier;
+    }
+
+    public User(String mUsername, String mFirstName, String mLastName,
+                int mId, String mImage, String mDateJoined, String mStatus) {
+        this(mUsername, mFirstName, mLastName, mId, mImage, mDateJoined, mStatus,
+                SubscriptionTier.BASIC);
     }
 
     public User(String firstName, String image) {
@@ -52,5 +61,13 @@ public class User {
 
     public String getStatus() {
         return mStatus;
+    }
+
+    public SubscriptionTier getSubscriptionTier() {
+        return mSubscriptionTier;
+    }
+
+    public void setSubscriptionTier(SubscriptionTier tier) {
+        this.mSubscriptionTier = tier;
     }
 }

--- a/README.md
+++ b/README.md
@@ -52,6 +52,11 @@ Travel Mate gives a bunch of helpful utilities in one app including World Clock,
 | <img src="https://raw.githubusercontent.com/project-travel-mate/Travel-Mate/master/.github/screenshots/world_clock.jpeg" width="200px"> | <img src="https://raw.githubusercontent.com/project-travel-mate/Travel-Mate/master/.github/screenshots/share_my_contact.png" width="200px"> | <img src="https://raw.githubusercontent.com/project-travel-mate/Travel-Mate/master/.github/screenshots/checklist.png" width="200px"> |
 | - | - | - |
 
+### Premium Plans
+Unlock extra travel tools with a subscription. **Basic** users enjoy standard
+features, **Pro** users gain itinerary generation and chat support, while
+**Concierge** members get personalised hidden gem recommendations.
+
 ### Contributing
 Check out the [Getting Started](GETTING_STARTED.md) page to add an awesome new feature or bash some bugs. If you're new to open-source, we recommend you to checkout our [Contributing Guidelines](CONTRIBUTING.md). 
 


### PR DESCRIPTION
## Summary
- support subscription tiers for users
- create premium utilities for itinerary generation, concierge features and basic validation
- document premium plan options

## Testing
- `./gradlew test --no-daemon` *(fails: No route to host)*