### PR TITLE
Fix checklist deletion and improve undo

### DIFF
--- a/Android/app/src/main/java/dao/WidgetCheckListDao.java
+++ b/Android/app/src/main/java/dao/WidgetCheckListDao.java
@@ -39,4 +39,7 @@ public interface WidgetCheckListDao {
 
     @Query("DELETE FROM events_new")
     void deleteAll();
+
+    @Query("DELETE FROM events_new WHERE isDone = 1")
+    void deleteCompletedTasks();
 }

--- a/Android/app/src/main/java/io/github/project_travel_mate/roompersistence/ChecklistDataSource.java
+++ b/Android/app/src/main/java/io/github/project_travel_mate/roompersistence/ChecklistDataSource.java
@@ -60,6 +60,13 @@ public class ChecklistDataSource {
         mDao.insertItem(item);
     }
 
+    /**
+     * Insert multiple items in a single transaction.
+     */
+    void insertItems(List<ChecklistItem> items) {
+        mDao.insertItems(items);
+    }
+
     void deleteItem(ChecklistItem item) {
         mDao.deleteItem(item);
     }

--- a/Android/app/src/main/java/io/github/project_travel_mate/roompersistence/ChecklistItemDAO.java
+++ b/Android/app/src/main/java/io/github/project_travel_mate/roompersistence/ChecklistItemDAO.java
@@ -22,6 +22,9 @@ public interface ChecklistItemDAO {
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     void insertItem(ChecklistItem item);
 
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    void insertItems(List<ChecklistItem> items);
+
     @Query("SELECT * FROM events_new ORDER BY isDone")
     Flowable<List<ChecklistItem>> getSortedItems();
 

--- a/Android/app/src/main/java/io/github/project_travel_mate/roompersistence/ChecklistViewModel.java
+++ b/Android/app/src/main/java/io/github/project_travel_mate/roompersistence/ChecklistViewModel.java
@@ -65,6 +65,10 @@ public class ChecklistViewModel extends ViewModel {
         return Completable.fromAction(() -> mDataSource.insertItem(item));
     }
 
+    public Completable insertItems(List<ChecklistItem> items) {
+        return Completable.fromAction(() -> mDataSource.insertItems(items));
+    }
+
     public Completable deleteItem(ChecklistItem item) {
         return Completable.fromAction(() -> mDataSource.deleteItem(item));
     }

--- a/Android/app/src/main/java/io/github/project_travel_mate/utilities/ChecklistFragment.java
+++ b/Android/app/src/main/java/io/github/project_travel_mate/utilities/ChecklistFragment.java
@@ -260,21 +260,19 @@ public class ChecklistFragment extends Fragment implements TravelmateSnackbars,
                 .subscribeOn(Schedulers.io())
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe());
-        // TODO make this deleteCompleted tasks
-        mDatabase.widgetCheckListDao().deleteAll();
+        // Also remove from the widget DB
+        mDatabase.widgetCheckListDao().deleteCompletedTasks();
         //creates a snackbar with undo option
         TravelmateSnackbars.createSnackBar(mActivity.findViewById(R.id.checklist_root_layout),
                 R.string.deleted_task_message,
                 Snackbar.LENGTH_LONG)
                 .setAction(R.string.undo, v -> {
-                    // TODO can replace this with a single multi-item insert statement
-                    for (int i = 0; i < mItems.size(); i++) {
-                        //adds all completed task in database again
-                        mDisposable.add(mViewModel.insertItem(mItems.get(i))
+                    if (!mItems.isEmpty()) {
+                        mDisposable.add(mViewModel.insertItems(mItems)
                                 .subscribeOn(Schedulers.io())
                                 .observeOn(AndroidSchedulers.mainThread())
                                 .subscribe());
-                        mDatabase.widgetCheckListDao().insert(mItems.get(i));
+                        mDatabase.widgetCheckListDao().insertAll(mItems);
                     }
 
                     if (mItems.size() > 0) mActionDeleteMenuItem.setVisible(true);


### PR DESCRIPTION
## Summary
- fix `deleteCompletedTasks()` so it only clears finished tasks
- add batch insert support in DAO/DataSource/ViewModel
- use efficient multi-item insert on undo
- document bulk insert method

## Testing
- `./gradlew test --console=plain` *(fails: No route to host)*