### PR TITLE
Add skeleton for smart itinerary builder

### DIFF
--- a/Android/app/build.gradle
+++ b/Android/app/build.gradle
@@ -2,6 +2,7 @@ apply plugin: 'com.android.application'
 apply from: '../config/checkstyle.gradle'
 apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
+apply plugin: 'kotlin-kapt'
 
 android {
     compileSdkVersion 28
@@ -78,7 +79,7 @@ dependencies {
     implementation 'com.jakewharton:butterknife:8.8.1'
     annotationProcessor 'com.jakewharton:butterknife-compiler:8.8.1'
     implementation "android.arch.persistence.room:runtime:$rootProject.roomVersion"
-    annotationProcessor "android.arch.persistence.room:compiler:$rootProject.roomVersion"
+    kapt "android.arch.persistence.room:compiler:$rootProject.roomVersion"
     implementation 'com.github.juanlabrador:badgecounter:1.0.2@aar'
     // Cloudinary : For profile photo upload
     implementation 'com.cloudinary:cloudinary-android:1.24.0'

--- a/Android/app/src/main/AndroidManifest.xml
+++ b/Android/app/src/main/AndroidManifest.xml
@@ -67,6 +67,10 @@
             android:label="@string/title_activity_select_city"
             android:theme="@style/AppTheme_picker" />
         <activity
+            android:name=".utilities.ItineraryBuilderActivity"
+            android:label="@string/itinerary_builder"
+            android:theme="@style/AppTheme_picker" />
+        <activity
             android:name=".travel.ShoppingCurrentCityActivity"
             android:label="@string/title_activity_shopping_currentcity"
             android:theme="@style/AppTheme_picker" />

--- a/Android/app/src/main/java/dao/ItineraryDao.kt
+++ b/Android/app/src/main/java/dao/ItineraryDao.kt
@@ -1,0 +1,26 @@
+package dao
+
+import android.arch.persistence.room.*
+import objects.Itinerary
+import objects.ItineraryItem
+
+@Dao
+interface ItineraryDao {
+    @Insert
+    fun insertItinerary(itinerary: Itinerary): Long
+
+    @Insert
+    fun insertItems(items: List<ItineraryItem>)
+
+    @Query("SELECT * FROM itineraries WHERE user_id = :userId")
+    fun getItineraries(userId: String): List<Itinerary>
+
+    @Query("SELECT * FROM itinerary_items WHERE itinerary_id = :itineraryId ORDER BY day, position")
+    fun getItems(itineraryId: Int): List<ItineraryItem>
+
+    @Update
+    fun updateItem(item: ItineraryItem)
+
+    @Delete
+    fun deleteItem(item: ItineraryItem)
+}

--- a/Android/app/src/main/java/database/AppDataBase.java
+++ b/Android/app/src/main/java/database/AppDataBase.java
@@ -10,14 +10,17 @@ import android.content.Context;
 
 import dao.CityDao;
 import dao.WidgetCheckListDao;
+import dao.ItineraryDao;
 import objects.ChecklistItem;
 import objects.City;
+import objects.Itinerary;
+import objects.ItineraryItem;
 
 /**
  * Created by Santosh on 05/09/18.
  */
 
-@Database(entities = {City.class, ChecklistItem.class}, version = 3, exportSchema = false)
+@Database(entities = {City.class, ChecklistItem.class, Itinerary.class, ItineraryItem.class}, version = 4, exportSchema = false)
 @TypeConverters({Converters.class})
 public abstract class AppDataBase extends RoomDatabase {
 
@@ -26,6 +29,7 @@ public abstract class AppDataBase extends RoomDatabase {
 
     public abstract CityDao cityDao();
     public abstract WidgetCheckListDao widgetCheckListDao();
+    public abstract ItineraryDao itineraryDao();
 
     public static AppDataBase getAppDatabase(Context context) {
         if (instance == null) {
@@ -33,7 +37,7 @@ public abstract class AppDataBase extends RoomDatabase {
                     AppDataBase.class,
                     "city-travel-mate-db")
                     .allowMainThreadQueries()
-                    .addMigrations(MIGRATION_1_2, MIGRATION_2_3)
+                    .addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4)
                     .build();
         }
         return instance;
@@ -45,6 +49,15 @@ public abstract class AppDataBase extends RoomDatabase {
         public void migrate(SupportSQLiteDatabase database) {
             // Add column to the table
             database.execSQL("ALTER TABLE city ADD city_favourite INTEGER DEFAULT 0 NOT NULL");
+        }
+    };
+
+    //migration from database version 3 to 4
+    static final Migration MIGRATION_3_4 = new Migration(3, 4) {
+        @Override
+        public void migrate(SupportSQLiteDatabase database) {
+            database.execSQL("CREATE TABLE IF NOT EXISTS itineraries (itinerary_id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, user_id TEXT NOT NULL, name TEXT NOT NULL, days INTEGER NOT NULL)");
+            database.execSQL("CREATE TABLE IF NOT EXISTS itinerary_items (item_id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, itinerary_id INTEGER NOT NULL, day INTEGER NOT NULL, activity TEXT NOT NULL, position INTEGER NOT NULL)");
         }
     };
 

--- a/Android/app/src/main/java/io/github/project_travel_mate/utilities/ItineraryAdapter.kt
+++ b/Android/app/src/main/java/io/github/project_travel_mate/utilities/ItineraryAdapter.kt
@@ -1,0 +1,48 @@
+package io.github.project_travel_mate.utilities
+
+import android.support.v7.widget.RecyclerView
+import android.view.LayoutInflater
+import android.view.MotionEvent
+import android.view.View
+import android.view.ViewGroup
+import android.widget.ImageView
+import android.widget.TextView
+import objects.ItineraryItem
+import io.github.project_travel_mate.R
+
+class ItineraryAdapter(private val items: MutableList<ItineraryItem>, private val dragStartListener: DragStartListener)
+    : RecyclerView.Adapter<ItineraryAdapter.ViewHolder>() {
+
+    interface DragStartListener {
+        fun onStartDrag(holder: RecyclerView.ViewHolder)
+    }
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
+        val view = LayoutInflater.from(parent.context).inflate(R.layout.item_itinerary, parent, false)
+        return ViewHolder(view)
+    }
+
+    override fun onBindViewHolder(holder: ViewHolder, position: Int) {
+        val item = items[position]
+        holder.text.text = item.activity
+        holder.handle.setOnTouchListener { _, event ->
+            if (event.actionMasked == MotionEvent.ACTION_DOWN) {
+                dragStartListener.onStartDrag(holder)
+            }
+            false
+        }
+    }
+
+    override fun getItemCount(): Int = items.size
+
+    fun onItemMove(from: Int, to: Int) {
+        val item = items.removeAt(from)
+        items.add(to, item)
+        notifyItemMoved(from, to)
+    }
+
+    inner class ViewHolder(view: View) : RecyclerView.ViewHolder(view) {
+        val text: TextView = view.findViewById(R.id.row_text)
+        val handle: ImageView = view.findViewById(R.id.row_handle)
+    }
+}

--- a/Android/app/src/main/java/io/github/project_travel_mate/utilities/ItineraryBuilderActivity.java
+++ b/Android/app/src/main/java/io/github/project_travel_mate/utilities/ItineraryBuilderActivity.java
@@ -1,0 +1,43 @@
+package io.github.project_travel_mate.utilities;
+
+import android.content.Context;
+import android.content.Intent;
+import android.os.Bundle;
+import android.support.v4.app.Fragment;
+import android.support.v4.app.FragmentManager;
+import android.support.v7.app.AppCompatActivity;
+import android.support.v7.widget.Toolbar;
+
+import java.util.Objects;
+
+import io.github.project_travel_mate.R;
+
+public class ItineraryBuilderActivity extends AppCompatActivity {
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_itinerary_builder);
+
+        Toolbar toolbar = findViewById(R.id.toolbar);
+        setSupportActionBar(toolbar);
+
+        FragmentManager fragmentManager = getSupportFragmentManager();
+        Fragment fragment = ItineraryBuilderFragment.newInstance();
+        fragmentManager.beginTransaction().replace(R.id.itinerary_root_layout, fragment).commit();
+
+        setTitle(getString(R.string.itinerary_builder));
+        Objects.requireNonNull(getSupportActionBar()).setDisplayHomeAsUpEnabled(true);
+        getSupportActionBar().setHomeButtonEnabled(true);
+    }
+
+    @Override
+    public boolean onSupportNavigateUp() {
+        finish();
+        return true;
+    }
+
+    public static Intent getStartIntent(Context context) {
+        return new Intent(context, ItineraryBuilderActivity.class);
+    }
+}

--- a/Android/app/src/main/java/io/github/project_travel_mate/utilities/ItineraryBuilderFragment.kt
+++ b/Android/app/src/main/java/io/github/project_travel_mate/utilities/ItineraryBuilderFragment.kt
@@ -1,0 +1,65 @@
+package io.github.project_travel_mate.utilities
+
+import android.app.Activity
+import android.content.Context
+import android.os.Bundle
+import android.support.v4.app.Fragment
+import android.support.v7.widget.LinearLayoutManager
+import android.support.v7.widget.RecyclerView
+import android.support.v7.widget.helper.ItemTouchHelper
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+
+import io.github.project_travel_mate.R
+import objects.Itinerary
+import utils.ItineraryGenerator
+import database.AppDataBase
+import dao.ItineraryDao
+
+class ItineraryBuilderFragment : Fragment(), ItineraryAdapter.DragStartListener {
+
+    private lateinit var recyclerView: RecyclerView
+    private lateinit var adapter: ItineraryAdapter
+    private lateinit var database: AppDataBase
+    private lateinit var itineraryDao: ItineraryDao
+    private lateinit var touchHelper: ItemTouchHelper
+    private var activityContext: Activity? = null
+
+    companion object {
+        fun newInstance(): ItineraryBuilderFragment {
+            return ItineraryBuilderFragment()
+        }
+    }
+
+    override fun onAttach(context: Context) {
+        super.onAttach(context)
+        activityContext = context as Activity
+    }
+
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
+        val view = inflater.inflate(R.layout.fragment_itinerary_builder, container, false)
+        recyclerView = view.findViewById(R.id.itinerary_recycler)
+        database = AppDataBase.getAppDatabase(activityContext)
+        itineraryDao = database.itineraryDao()
+
+        val itinerary = Itinerary(userId = "local", name = "Sample Trip", days = 3)
+        val id = itineraryDao.insertItinerary(itinerary).toInt()
+        val items = ItineraryGenerator.generate(itinerary.days, id)
+        itineraryDao.insertItems(items)
+
+        adapter = ItineraryAdapter(itineraryDao.getItems(id), this)
+        recyclerView.layoutManager = LinearLayoutManager(context)
+        recyclerView.adapter = adapter
+
+        val callback = ItineraryDragCallback(adapter)
+        touchHelper = ItemTouchHelper(callback)
+        touchHelper.attachToRecyclerView(recyclerView)
+
+        return view
+    }
+
+    override fun onStartDrag(holder: RecyclerView.ViewHolder) {
+        touchHelper.startDrag(holder)
+    }
+}

--- a/Android/app/src/main/java/io/github/project_travel_mate/utilities/ItineraryDragCallback.kt
+++ b/Android/app/src/main/java/io/github/project_travel_mate/utilities/ItineraryDragCallback.kt
@@ -1,0 +1,25 @@
+package io.github.project_travel_mate.utilities
+
+import android.support.v7.widget.RecyclerView
+import android.support.v7.widget.helper.ItemTouchHelper
+
+class ItineraryDragCallback(private val adapter: ItineraryAdapter) : ItemTouchHelper.Callback() {
+
+    override fun getMovementFlags(recyclerView: RecyclerView, viewHolder: RecyclerView.ViewHolder): Int {
+        val dragFlags = ItemTouchHelper.UP or ItemTouchHelper.DOWN
+        return makeMovementFlags(dragFlags, 0)
+    }
+
+    override fun onMove(recyclerView: RecyclerView, viewHolder: RecyclerView.ViewHolder, target: RecyclerView.ViewHolder): Boolean {
+        val fromPos = viewHolder.adapterPosition
+        val toPos = target.adapterPosition
+        adapter.onItemMove(fromPos, toPos)
+        return true
+    }
+
+    override fun onSwiped(viewHolder: RecyclerView.ViewHolder, direction: Int) {
+        // no swipe actions
+    }
+
+    override fun isLongPressDragEnabled(): Boolean = false
+}

--- a/Android/app/src/main/java/io/github/project_travel_mate/utilities/UtilitiesFragment.java
+++ b/Android/app/src/main/java/io/github/project_travel_mate/utilities/UtilitiesFragment.java
@@ -98,6 +98,10 @@ public class UtilitiesFragment extends Fragment implements CardViewOptionsAdapte
                 intent = UpcomingWeekendsActivity.getStartIntent(mActivity);
                 startActivity(intent);
                 break;
+            case 6:
+                intent = ItineraryBuilderActivity.getStartIntent(mActivity);
+                startActivity(intent);
+                break;
         }
     }
 
@@ -129,6 +133,10 @@ public class UtilitiesFragment extends Fragment implements CardViewOptionsAdapte
                 new CardItemEntity(
                         getActivity().getDrawable(R.drawable.upcoming_long_weekends),
                         getResources().getString(R.string.upcoming_long_weekends)));
+        cardEntities.add(
+                new CardItemEntity(
+                        getActivity().getDrawable(R.drawable.ic_event),
+                        getResources().getString(R.string.itinerary_builder)));
         if (!mHasMagneticSensor) {
             cardEntities.add(
                     new CardItemEntity(

--- a/Android/app/src/main/java/objects/Itinerary.kt
+++ b/Android/app/src/main/java/objects/Itinerary.kt
@@ -1,0 +1,19 @@
+package objects
+
+import android.arch.persistence.room.ColumnInfo
+import android.arch.persistence.room.Entity
+import android.arch.persistence.room.PrimaryKey
+import java.io.Serializable
+
+@Entity(tableName = "itineraries")
+data class Itinerary(
+    @PrimaryKey(autoGenerate = true)
+    @ColumnInfo(name = "itinerary_id")
+    var id: Int = 0,
+    @ColumnInfo(name = "user_id")
+    var userId: String,
+    @ColumnInfo(name = "name")
+    var name: String,
+    @ColumnInfo(name = "days")
+    var days: Int
+) : Serializable

--- a/Android/app/src/main/java/objects/ItineraryItem.kt
+++ b/Android/app/src/main/java/objects/ItineraryItem.kt
@@ -1,0 +1,26 @@
+package objects
+
+import android.arch.persistence.room.ColumnInfo
+import android.arch.persistence.room.Entity
+import android.arch.persistence.room.ForeignKey
+import android.arch.persistence.room.PrimaryKey
+import java.io.Serializable
+
+@Entity(tableName = "itinerary_items",
+        foreignKeys = [ForeignKey(entity = Itinerary::class,
+                parentColumns = ["itinerary_id"],
+                childColumns = ["itinerary_id"],
+                onDelete = ForeignKey.CASCADE)])
+data class ItineraryItem(
+    @PrimaryKey(autoGenerate = true)
+    @ColumnInfo(name = "item_id")
+    var id: Int = 0,
+    @ColumnInfo(name = "itinerary_id", index = true)
+    var itineraryId: Int,
+    @ColumnInfo(name = "day")
+    var day: Int,
+    @ColumnInfo(name = "activity")
+    var activity: String,
+    @ColumnInfo(name = "position")
+    var position: Int
+) : Serializable

--- a/Android/app/src/main/java/utils/ItineraryGenerator.kt
+++ b/Android/app/src/main/java/utils/ItineraryGenerator.kt
@@ -1,0 +1,24 @@
+package utils
+
+import objects.ItineraryItem
+
+object ItineraryGenerator {
+    private val defaultActivities = listOf(
+        "Breakfast",
+        "Morning sightseeing",
+        "Lunch",
+        "Afternoon tour",
+        "Dinner"
+    )
+
+    fun generate(days: Int, itineraryId: Int = 0): List<ItineraryItem> {
+        val items = mutableListOf<ItineraryItem>()
+        for (day in 1..days) {
+            var position = 0
+            for (activity in defaultActivities) {
+                items.add(ItineraryItem(0, itineraryId, day, activity, position++))
+            }
+        }
+        return items
+    }
+}

--- a/Android/app/src/main/res/drawable/ic_drag_handle_black_24dp.xml
+++ b/Android/app/src/main/res/drawable/ic_drag_handle_black_24dp.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24.0"
+    android:viewportHeight="24.0">
+    <path
+        android:fillColor="#000"
+        android:pathData="M4,9h16v2H4zM4,13h16v2H4z"/>
+</vector>

--- a/Android/app/src/main/res/layout/activity_itinerary_builder.xml
+++ b/Android/app/src/main/res/layout/activity_itinerary_builder.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<android.support.design.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:fitsSystemWindows="true">
+
+    <android.support.design.widget.AppBarLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:theme="@style/AppTheme.AppBarOverlay">
+
+        <android.support.v7.widget.Toolbar
+            android:id="@+id/toolbar"
+            android:layout_width="match_parent"
+            android:layout_height="?android:attr/actionBarSize"
+            android:background="?android:attr/colorPrimary"
+            app:popupTheme="@style/AppTheme.PopupOverlay" />
+
+    </android.support.design.widget.AppBarLayout>
+
+    <FrameLayout
+        android:id="@+id/itinerary_root_layout"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        app:layout_behavior="@string/appbar_scrolling_view_behavior" />
+
+</android.support.design.widget.CoordinatorLayout>

--- a/Android/app/src/main/res/layout/fragment_itinerary_builder.xml
+++ b/Android/app/src/main/res/layout/fragment_itinerary_builder.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical">
+
+    <android.support.v7.widget.RecyclerView
+        android:id="@+id/itinerary_recycler"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent" />
+</LinearLayout>

--- a/Android/app/src/main/res/layout/item_itinerary.xml
+++ b/Android/app/src/main/res/layout/item_itinerary.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="horizontal"
+    android:padding="8dp">
+
+    <ImageView
+        android:id="@+id/row_handle"
+        android:layout_width="24dp"
+        android:layout_height="24dp"
+        android:src="@drawable/ic_drag_handle_black_24dp"
+        android:layout_gravity="center_vertical" />
+
+    <TextView
+        android:id="@+id/row_text"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_weight="1"
+        android:text="Activity" />
+</LinearLayout>

--- a/Android/app/src/main/res/values/strings.xml
+++ b/Android/app/src/main/res/values/strings.xml
@@ -81,6 +81,7 @@
 
     <!-- Checklist strings -->
     <string name="text_checklist">Checklist</string>
+    <string name="itinerary_builder">Itinerary Builder</string>
     <string name="enter_task_name">Enter task name</string>
     <string name="menu_delete_completed">Delete ticked items</string>
     <string name="delete_tasks">Are you sure you want to delete all completed tasks?</string>


### PR DESCRIPTION
## Summary
- start itinerary feature tables & DAO
- generate default itinerary items
- add itinerary builder UI skeleton with drag & drop
- hook itinerary builder into utilities menu
- enable Room Kotlin annotation processing via `kapt`

## Testing
- `./gradlew checkstyle` *(fails: No route to host)*
- `./gradlew assembleDebug assembleRelease` *(fails: No route to host)*